### PR TITLE
Self-Contained Proofs 📦

### DIFF
--- a/REST/EPAccount.go
+++ b/REST/EPAccount.go
@@ -1,9 +1,8 @@
 package REST
 
 import (
+	"fmt"
 	"github.com/bazo-blockchain/bazo-client/client"
-	"github.com/bazo-blockchain/bazo-client/network"
-	"github.com/bazo-blockchain/bazo-miner/protocol"
 	"github.com/gorilla/mux"
 	"math/big"
 	"net/http"
@@ -16,22 +15,13 @@ func GetAccountEndpoint(w http.ResponseWriter, req *http.Request) {
 	logger.Printf("Incoming acc request for id: %v", param)
 
 	var address [64]byte
-	var addressHash [32]byte
 
 	pubKeyInt, _ := new(big.Int).SetString(param, 16)
 
-	if len(param) == 64 {
-		copy(addressHash[:], pubKeyInt.Bytes())
-
-		network.AccReq(false, addressHash)
-
-		accI, _ := network.Fetch(network.AccChan)
-		acc := accI.(*protocol.Account)
-
-		address = acc.Address
-	} else if len(param) == 128 {
+	if len(param) == 128 {
 		copy(address[:], pubKeyInt.Bytes())
-		addressHash = protocol.SerializeHashContent(address)
+	} else {
+		logger.Fatal(fmt.Sprintf("provided invalid address %x\n", param))
 	}
 
 	acc, lastTenTx, err := client.GetAccount(address)

--- a/cli/account.go
+++ b/cli/account.go
@@ -62,8 +62,6 @@ func checkAccount(args *accountArgs, logger *log.Logger) error {
 		address = crypto.GetAddressFromPubKey(&privKey.PublicKey)
 	}
 
-	logger.Printf("My address: %x\n", address)
-
 	acc, _, err := client.CheckAccount(address)
 	if err != nil {
 		logger.Println(err)

--- a/cli/funds.go
+++ b/cli/funds.go
@@ -120,7 +120,6 @@ func sendFunds(args *fundsArgs, logger *log.Logger) error {
 	fromAddress := crypto.GetAddressFromPubKey(&fromPrivKey.PublicKey)
 	toAddress := crypto.GetAddressFromPubKey(toPubKey)
 
-	scp := protocol.NewSCP()
 	proofs, err := cstorage.ReadMerkleProofs()
 	sort.Slice(proofs, func(i, j int) bool {
 		return proofs[i].Height > proofs[j].Height
@@ -141,7 +140,7 @@ func sendFunds(args *fundsArgs, logger *log.Logger) error {
 		return err
 	}
 
-	tx.Proof = &scp
+	tx.Proofs = proofs
 
 	if err := network.SendTx(util.Config.BootstrapIpport, tx, p2p.FUNDSTX_BRDCST); err != nil {
 		logger.Printf("%v\n", err)

--- a/cli/funds.go
+++ b/cli/funds.go
@@ -119,6 +119,8 @@ func sendFunds(args *fundsArgs, logger *log.Logger) error {
 	fromAddress := crypto.GetAddressFromPubKey(&fromPrivKey.PublicKey)
 	toAddress := crypto.GetAddressFromPubKey(toPubKey)
 
+	client.SyncBeforeTx(fromAddress)
+
 	proofs, err := cstorage.ReadMerkleProofs()
 	sort.Slice(proofs, func(i, j int) bool {
 		return proofs[i].Height > proofs[j].Height

--- a/cli/funds.go
+++ b/cli/funds.go
@@ -32,10 +32,7 @@ func GetFundsCommand(logger *log.Logger) cli.Command {
 		Usage:	"send funds from one account to another",
 		Action:	func(c *cli.Context) error {
 			client.Init()
-			err := client.Sync()
-			if err != nil {
-				return err
-			}
+			client.Sync()
 
 			args := &fundsArgs{
 				header: 		c.Int("header"),

--- a/cli/funds.go
+++ b/cli/funds.go
@@ -32,7 +32,6 @@ func GetFundsCommand(logger *log.Logger) cli.Command {
 		Usage:	"send funds from one account to another",
 		Action:	func(c *cli.Context) error {
 			client.Init()
-			client.Sync()
 
 			args := &fundsArgs{
 				header: 		c.Int("header"),

--- a/cli/funds.go
+++ b/cli/funds.go
@@ -124,7 +124,7 @@ func sendFunds(args *fundsArgs, logger *log.Logger) error {
 		return proofs[i].Height > proofs[j].Height
 	})
 
-	tx, err := protocol.ConstrFundsTx(
+	tx, err := protocol.NewSignedFundsTx(
 		byte(args.header),
 		uint64(args.amount),
 		uint64(args.fee),

--- a/cli/rest.go
+++ b/cli/rest.go
@@ -11,7 +11,11 @@ func GetRestCommand() cli.Command {
 		Name:	"rest",
 		Usage:	"start the REST service",
 		Action:	func(c *cli.Context) error {
-			client.Sync()
+			err := client.Sync()
+			if err != nil {
+				return err
+			}
+
 			REST.Init()
 			return nil
 		},

--- a/cli/rest.go
+++ b/cli/rest.go
@@ -11,11 +11,7 @@ func GetRestCommand() cli.Command {
 		Name:	"rest",
 		Usage:	"start the REST service",
 		Action:	func(c *cli.Context) error {
-			err := client.Sync()
-			if err != nil {
-				return err
-			}
-
+			client.Sync()
 			REST.Init()
 			return nil
 		},

--- a/cli/rest.go
+++ b/cli/rest.go
@@ -11,6 +11,7 @@ func GetRestCommand() cli.Command {
 		Name:	"rest",
 		Usage:	"start the REST service",
 		Action:	func(c *cli.Context) error {
+			client.Init()
 			client.Sync()
 			REST.Init()
 			return nil

--- a/client/account.go
+++ b/client/account.go
@@ -31,13 +31,13 @@ func GetAccount(address [64]byte) (*Account, []*FundsTxJson, error) {
 	//Set default params
 	activeParameters = miner.NewDefaultParameters()
 
-	network.AccReq(false, protocol.SerializeHashContent(account.Address))
+	network.AccReq(false, account.Address)
 	if accI, _ := network.Fetch(network.AccChan); accI != nil {
 		if acc := accI.(*protocol.Account); acc != nil {
 			account.IsCreated = true
 			account.IsStaking = acc.IsStaking
 
-			network.AccReq(true, protocol.SerializeHashContent(account.Address))
+			network.AccReq(true, account.Address)
 			if rootAccI, _ := network.Fetch(network.AccChan); rootAccI != nil {
 				if rootAcc := rootAccI.(*protocol.Account); rootAcc != nil {
 					account.IsRoot = true

--- a/client/state.go
+++ b/client/state.go
@@ -21,36 +21,23 @@ var (
 )
 
 //Update allBlockHeaders to the latest header. Start listening to broadcasted headers after.
-func Sync() error {
-	err := loadBlockHeaders()
-	if err != nil {
-		return err
-	}
-
+func Sync() {
+	loadBlockHeaders()
 	go incomingBlockHeaders()
-
-	return nil
 }
 
-func loadBlockHeaders() error {
+func loadBlockHeaders() {
+	var last *protocol.Block
 
 	//youngest = fetchBlockHeader(nil)
-	last, err := cstorage.ReadLastBlockHeader()
-	if err != nil || last == nil {
-		return err
+	if last, _ = cstorage.ReadLastBlockHeader(); last != nil {
+		var loaded []*protocol.Block
+		loaded = loadDB(last, [32]byte{}, loaded)
+		blockHeaders = append(blockHeaders, loaded...)
 	}
-
-	loaded, err := loadDB(last, [32]byte{}, []*protocol.Block{})
-	if err != nil {
-		return err
-	}
-
-	blockHeaders = append(blockHeaders, loaded...)
 
 	//The client is up to date with the network and can start listening for incoming headers.
 	network.Uptodate = true
-
-	return nil
 }
 
 func incomingBlockHeaders() {
@@ -127,17 +114,15 @@ func fetchBlockHeader(blockHash []byte) (blockHeader *protocol.Block) {
 	return blockHeader
 }
 
-func loadDB(last *protocol.Block, abort [32]byte, loaded []*protocol.Block) ([]*protocol.Block, error) {
+func loadDB(last *protocol.Block, abort [32]byte, loaded []*protocol.Block) []*protocol.Block {
+	var ancestor *protocol.Block
+
 	if last.PrevHash != abort {
-		ancestor, err := cstorage.ReadBlockHeader(last.PrevHash)
-		if err != nil {
-			return nil, err
+		if ancestor, _ = cstorage.ReadBlockHeader(last.PrevHash); ancestor == nil {
+			logger.Fatal()
 		}
 
-		loaded, err = loadDB(ancestor, abort, loaded)
-		if err != nil {
-			return nil, err
-		}
+		loaded = loadDB(ancestor, abort, loaded)
 	}
 
 	logger.Printf("Header %x with height %v loaded from DB\n",
@@ -146,7 +131,7 @@ func loadDB(last *protocol.Block, abort [32]byte, loaded []*protocol.Block) ([]*
 
 	loaded = append(loaded, last)
 
-	return loaded, nil
+	return loaded
 }
 
 func loadNetwork(last *protocol.Block, abort [32]byte, loaded []*protocol.Block) []*protocol.Block {
@@ -245,14 +230,12 @@ func getState(acc *Account, lastTenTx []*FundsTxJson) (err error) {
 						acc.TxCnt += 1
 					}
 
-					// Check if account is recipient of a transaction
 					if fundsTx.To == acc.Address {
 						acc.Balance += fundsTx.Amount
 
 						put(lastTenTx, ConvertFundsTx(fundsTx, "verified"))
 					}
 
-					// Check if account is beneficiary of a block
 					if block.Beneficiary == acc.Address {
 						acc.Balance += fundsTx.Fee
 					}

--- a/client/state.go
+++ b/client/state.go
@@ -219,6 +219,8 @@ func getState(acc *Account, lastTenTx []*FundsTxJson) (err error) {
 						return err
 					}
 
+					logger.Printf("Merkle proof written to client storage for tx at block height %v", block.Height)
+
 					// Check if account is sender of a transaction
 					if fundsTx.From == acc.Address {
 						//If Acc is no root, balance funds

--- a/client/state.go
+++ b/client/state.go
@@ -229,7 +229,7 @@ func requestFundsTx(block *protocol.Block) (fundsTxs []*protocol.FundsTx, err er
 }
 
 func balanceFunds(fundsTxs []*protocol.FundsTx, block *protocol.Block, acc *Account, lastTenTx []*FundsTxJson) error {
-	merkleTree := protocol.BuildMerkleTree(block)
+	merkleTree := block.BuildMerkleTree()
 
 	for _, fundsTx := range fundsTxs {
 		txHash := fundsTx.Hash()

--- a/client/util.go
+++ b/client/util.go
@@ -12,20 +12,14 @@ var (
 	logger     *log.Logger
 )
 
-func Init() error {
+func Init() {
 	p2p.InitLogging()
 	logger = util.InitLogger()
 
 	util.Config = util.LoadConfiguration()
 
 	network.Init()
-	err := cstorage.Init("client.db")
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	cstorage.Init("client.db")
 }
 
 func put(slice []*FundsTxJson, tx *FundsTxJson) {

--- a/client/util.go
+++ b/client/util.go
@@ -12,14 +12,20 @@ var (
 	logger     *log.Logger
 )
 
-func Init() {
+func Init() error {
 	p2p.InitLogging()
 	logger = util.InitLogger()
 
 	util.Config = util.LoadConfiguration()
 
 	network.Init()
-	cstorage.Init("client.db")
+	err := cstorage.Init("client.db")
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func put(slice []*FundsTxJson, tx *FundsTxJson) {

--- a/client/validate.go
+++ b/client/validate.go
@@ -32,9 +32,9 @@ func validateTx(block *protocol.Block, tx protocol.Transaction, txHash [32]byte)
 	for i := 0; i < len(nodes); i += 2 {
 		var parentHash [32]byte
 		concatHash := append(leafHash[:], nodes[i][:]...)
-		if parentHash = protocol.SerializeHashContent(concatHash); parentHash != nodes[i+1] {
+		if parentHash = protocol.MTHash(concatHash); parentHash != nodes[i+1] {
 			concatHash = append(nodes[i][:], leafHash[:]...)
-			if parentHash = protocol.SerializeHashContent(concatHash); parentHash != nodes[i+1] {
+			if parentHash = protocol.MTHash(concatHash); parentHash != nodes[i+1] {
 				valid = false
 			}
 		}

--- a/client/validate.go
+++ b/client/validate.go
@@ -47,3 +47,30 @@ func validateTx(block *protocol.Block, tx protocol.Transaction, txHash [32]byte)
 
 	return nil
 }
+
+func validateBucket(block *protocol.Block, bucketHash [32]byte) error {
+	err := network.IntermediateNodesReq(block.Hash, bucketHash)
+	if err != nil {
+		return err
+	}
+
+	nodes, err := network.Fetch32Bytes(network.IntermediateNodesChan)
+	if err != nil {
+		return err
+	}
+
+	leafHash := bucketHash
+	for i := 0; i < len(nodes); i += 2 {
+		var parentHash [32]byte
+		concatHash := append(leafHash[:], nodes[i][:]...)
+		if parentHash = protocol.MTHash(concatHash); parentHash != nodes[i+1] {
+			concatHash = append(nodes[i][:], leafHash[:]...)
+			if parentHash = protocol.MTHash(concatHash); parentHash != nodes[i+1] {
+				return errors.New(fmt.Sprintf("Bucket validation failed for %x\n", bucketHash))
+			}
+		}
+		leafHash = parentHash
+	}
+
+	return nil
+}

--- a/cstorage/delete.go
+++ b/cstorage/delete.go
@@ -2,11 +2,9 @@ package cstorage
 
 import "github.com/boltdb/bolt"
 
-func DeleteBlockHeader(hash [32]byte) {
-	db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("blockheaders"))
-		err := b.Delete(hash[:])
-
-		return err
+func DeleteBlockHeader(hash [32]byte) error {
+	return db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(BLOCKHEADERS_BUCKET))
+		return b.Delete(hash[:])
 	})
 }

--- a/cstorage/read.go
+++ b/cstorage/read.go
@@ -1,39 +1,47 @@
 package cstorage
 
 import (
+	"errors"
+	"fmt"
 	"github.com/bazo-blockchain/bazo-miner/protocol"
 	"github.com/boltdb/bolt"
 )
 
-func ReadBlockHeader(hash [32]byte) (header *protocol.Block) {
-	db.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("blockheaders"))
+func ReadBlockHeader(hash [32]byte) (header *protocol.Block, err error) {
+	err = db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(BLOCKHEADERS_BUCKET))
 		encodedHeader := b.Get(hash[:])
 		header = header.Decode(encodedHeader)
-
 		return nil
 	})
 
-	if header == nil {
-		return nil
+	if err != nil {
+		return nil, err
 	}
 
-	return header
+	if header == nil {
+		return nil, errors.New(fmt.Sprintf("header not found for hash %x\n", hash))
+	}
+
+	return header, nil
 }
 
-func ReadLastBlockHeader() (header *protocol.Block) {
-	db.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("lastblockheader"))
+func ReadLastBlockHeader() (header *protocol.Block, err error) {
+	err = db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(LASTBLOCKHEADER_BUCKET))
 		cb := b.Cursor()
 		_, encodedHeader := cb.First()
 		header = header.Decode(encodedHeader)
-
 		return nil
 	})
 
-	if header == nil {
-		return nil
+	if err != nil {
+		return nil, err
 	}
 
-	return header
+	if header == nil {
+		return nil, errors.New("last block header not found")
+	}
+
+	return header, nil
 }

--- a/cstorage/read.go
+++ b/cstorage/read.go
@@ -45,3 +45,36 @@ func ReadLastBlockHeader() (header *protocol.Block, err error) {
 
 	return header, nil
 }
+
+func ReadMerkleProof(hash [32]byte) (proof *protocol.MerkleProof, err error) {
+	err = db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(MERKLEPROOF_BUCKET))
+		encdoedProof := b.Get(hash[:])
+		proof = proof.Decode(encdoedProof)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return proof, nil
+}
+
+func ReadMerkleProofs() (proofs []*protocol.MerkleProof, err error) {
+	err = db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(MERKLEPROOF_BUCKET))
+
+		return b.ForEach(func(k, v []byte) error {
+			var proof *protocol.MerkleProof
+			proofs = append(proofs, proof.Decode(v))
+			return nil
+		})
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return proofs, nil
+}

--- a/cstorage/storage.go
+++ b/cstorage/storage.go
@@ -1,51 +1,45 @@
 package cstorage
 
 import (
-	"fmt"
 	"github.com/bazo-blockchain/bazo-client/util"
+	"github.com/bazo-blockchain/bazo-miner/storage"
 	"github.com/boltdb/bolt"
 	"log"
 	"time"
 )
 
 var (
-	db     *bolt.DB
-	logger *log.Logger
+	db     	*bolt.DB
+	logger 	*log.Logger
+	Buckets	[]string
 )
 
 const (
 	ERROR_MSG = "Initiate storage aborted: "
+	BLOCKHEADERS_BUCKET = "blockheaders"
+	LASTBLOCKHEADER_BUCKET = "lastblockheader"
 )
 
 //Entry function for the storage package
-func Init(dbname string) {
+func Init(dbname string) (err error) {
 	logger = util.InitLogger()
 
-	var err error
+	Buckets = []string {
+		BLOCKHEADERS_BUCKET,
+		LASTBLOCKHEADER_BUCKET,
+	}
+
 	db, err = bolt.Open(dbname, 0600, &bolt.Options{Timeout: 5 * time.Second})
 	if err != nil {
 		logger.Fatal(ERROR_MSG, err)
 	}
 
-	db.Update(func(tx *bolt.Tx) error {
-		_, err = tx.CreateBucket([]byte("blockheaders"))
+	for _, bucket := range Buckets {
+		err = storage.CreateBucket(bucket, db)
 		if err != nil {
-			return fmt.Errorf(ERROR_MSG+"Create bucket: %s", err)
+			return err
 		}
+	}
 
-		return nil
-	})
-
-	db.Update(func(tx *bolt.Tx) error {
-		_, err = tx.CreateBucket([]byte("lastblockheader"))
-		if err != nil {
-			return fmt.Errorf(ERROR_MSG+"Create bucket: %s", err)
-		}
-
-		return nil
-	})
-}
-
-func TearDown() {
-	db.Close()
+	return nil
 }

--- a/cstorage/storage.go
+++ b/cstorage/storage.go
@@ -18,6 +18,7 @@ const (
 	ERROR_MSG = "Initiate storage aborted: "
 	BLOCKHEADERS_BUCKET = "blockheaders"
 	LASTBLOCKHEADER_BUCKET = "lastblockheader"
+	MERKLEPROOF_BUCKET = "merkleproofs"
 )
 
 //Entry function for the storage package
@@ -27,6 +28,7 @@ func Init(dbname string) (err error) {
 	Buckets = []string {
 		BLOCKHEADERS_BUCKET,
 		LASTBLOCKHEADER_BUCKET,
+		MERKLEPROOF_BUCKET,
 	}
 
 	db, err = bolt.Open(dbname, 0600, &bolt.Options{Timeout: 5 * time.Second})

--- a/cstorage/write.go
+++ b/cstorage/write.go
@@ -30,3 +30,10 @@ func WriteLastBlockHeader(header *protocol.Block) (err error) {
 		return b.Put(header.Hash[:], header.EncodeHeader())
 	})
 }
+
+func WriteMerkleProof(proof *protocol.MerkleProof) (err error) {
+	return db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(MERKLEPROOF_BUCKET))
+		return b.Put(proof.Hash()[:], proof.Encode())
+	})
+}

--- a/cstorage/write.go
+++ b/cstorage/write.go
@@ -34,6 +34,7 @@ func WriteLastBlockHeader(header *protocol.Block) (err error) {
 func WriteMerkleProof(proof *protocol.MerkleProof) (err error) {
 	return db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(MERKLEPROOF_BUCKET))
-		return b.Put(proof.Hash()[:], proof.Encode())
+		key := proof.Hash()
+		return b.Put(key[:], proof.Encode())
 	})
 }

--- a/cstorage/write.go
+++ b/cstorage/write.go
@@ -6,35 +6,27 @@ import (
 )
 
 func WriteBlockHeader(header *protocol.Block) (err error) {
-	err = db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("blockheaders"))
-		err := b.Put(header.Hash[:], header.EncodeHeader())
-
-		return err
+	return db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(BLOCKHEADERS_BUCKET))
+		return b.Put(header.Hash[:], header.EncodeHeader())
 	})
-
-	return err
 }
 
 //Before saving the last block header, delete all existing entries.
 func WriteLastBlockHeader(header *protocol.Block) (err error) {
-	db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("lastblockheader"))
-		b.ForEach(func(k, v []byte) error {
-			b.Delete(k)
-
-			return nil
-		})
-
-		return nil
-	})
-
 	err = db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("lastblockheader"))
-		err := b.Put(header.Hash[:], header.EncodeHeader())
-
-		return err
+		b := tx.Bucket([]byte(LASTBLOCKHEADER_BUCKET))
+		return b.ForEach(func(k, v []byte) error {
+			return b.Delete(k)
+		})
 	})
 
-	return err
+	if err != nil {
+		return err
+	}
+
+	return db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(LASTBLOCKHEADER_BUCKET))
+		return b.Put(header.Hash[:], header.EncodeHeader())
+	})
 }

--- a/network/requests.go
+++ b/network/requests.go
@@ -43,7 +43,7 @@ func TxReq(txType uint8, txHash [32]byte) error {
 	return nil
 }
 
-func AccReq(root bool, addressHash [32]byte) error {
+func AccReq(root bool, address [64]byte) error {
 	p := peers.getRandomPeer()
 	if p == nil {
 		return errors.New("Couldn't get a connection, request not transmitted.")
@@ -51,9 +51,9 @@ func AccReq(root bool, addressHash [32]byte) error {
 
 	var packet []byte
 	if root {
-		packet = p2p.BuildPacket(p2p.ROOTACC_REQ, addressHash[:])
+		packet = p2p.BuildPacket(p2p.ROOTACC_REQ, address[:])
 	} else {
-		packet = p2p.BuildPacket(p2p.ACC_REQ, addressHash[:])
+		packet = p2p.BuildPacket(p2p.ACC_REQ, address[:])
 	}
 
 	sendData(p, packet)

--- a/network/responses.go
+++ b/network/responses.go
@@ -64,10 +64,7 @@ func txRes(p *peer, payload []byte, txType uint8) {
 
 func accRes(p *peer, payload []byte) {
 	var acc *protocol.Account
-	acc, err := acc.Decode(payload)
-	if err != nil {
-		logger.Fatal(err)
-	}
+	acc, _ = acc.Decode(payload)
 
 	AccChan <- acc
 }

--- a/network/responses.go
+++ b/network/responses.go
@@ -64,7 +64,10 @@ func txRes(p *peer, payload []byte, txType uint8) {
 
 func accRes(p *peer, payload []byte) {
 	var acc *protocol.Account
-	acc = acc.Decode(payload)
+	acc, err := acc.Decode(payload)
+	if err != nil {
+		logger.Fatal(err)
+	}
 
 	AccChan <- acc
 }


### PR DESCRIPTION
Hey there Bazo community 👋 

This is the complementary PR for the implementation of self-contained proofs in the [bazo-miner](https://github.com/bazo-blockchain/bazo-miner).

### Proof Calculation

The client of the Bazo blockchain plays an important role for self-contained proofs. A user is only able to create a self-contained proof if it can provide one Merkle proof for each transaction it was involved in. In other words, a user needs to keep track of all transactions where the sender or the receiver of the transaction equals to the user's address. The client software of the blockchain must be adapted to these requirements. We distinguish between _always-on_ and _just-in-time_ client software which we discuss below. 

* **Always-On**: maintains a constant connection to the network and receives all blocks sent through the network. This type of software is recommended for users which extensively interact with the network, i.e., users commonly sending or receiving transactions to or from the network respectively. This way, the list of Merkle proofs is always up-to-date and transactions can be sent very quickly, with the downside of having to run the software without interruption.
* **Just-In-Time**: downloads block headers and processes Merkle proofs just before a new transaction is sent to the network. The client software does not have to run constantly, however, it results in a delay if for example a user casually sends transactions and is far behind the current state of the blockchain. The process of saving a Merkle proof to local storage is identical as in always-on client software.

I decided to implement a just-in-time mechanism. When the command line is executed to send a FundsTx to the network, the client first syncs with the blockchain (in code [here](https://github.com/bazo-blockchain/bazo-client/blob/56d1bcd9487b7f9a33041b28a47e1356cb226554/cli/funds.go#L122) and [here](https://github.com/bazo-blockchain/bazo-client/blob/56d1bcd9487b7f9a33041b28a47e1356cb226554/client/state.go#L24))

Upon receiving a block, the algorithm processes as follows:
* Check if the block has already been processed. If yes, stop the algorithm, otherwise continue.
* Query the Bloom filter by the user's address. If it returns false, the block contains no transactions where the user is involved in, i.e., the user is neither sender or receiver of a transaction. If it returns true, continue.
* [Download all funds transaction](https://github.com/bazo-blockchain/bazo-client/blob/56d1bcd9487b7f9a33041b28a47e1356cb226554/client/state.go#L201) from a miner, find the transactions where the user was either sender or receiver, [add these transactions to a TxBucket](https://github.com/bazo-blockchain/bazo-client/blob/56d1bcd9487b7f9a33041b28a47e1356cb226554/client/state.go#L245) and calculate the [hash of the bucket](https://github.com/bazo-blockchain/bazo-client/blob/56d1bcd9487b7f9a33041b28a47e1356cb226554/client/state.go#L249). [Using this hash](https://github.com/bazo-blockchain/bazo-client/blob/56d1bcd9487b7f9a33041b28a47e1356cb226554/client/state.go#L250), the client can then [request all intermediate hashes](https://github.com/bazo-blockchain/bazo-client/blob/56d1bcd9487b7f9a33041b28a47e1356cb226554/client/validate.go#L51) of the block's Merkle tree and to finally derive the [Merkle proof](https://github.com/bazo-blockchain/bazo-client/blob/56d1bcd9487b7f9a33041b28a47e1356cb226554/client/state.go#L278) that can be [stored](https://github.com/bazo-blockchain/bazo-client/blob/56d1bcd9487b7f9a33041b28a47e1356cb226554/client/state.go#L285) in the local database.

### Proof Verification

Proofs are verified by the bazo-miner, which are explained [here](https://github.com/bazo-blockchain/bazo-miner/pull/28).

## Limitations

* False-Positive Proofs are not implemented yet, placeholders are [in code](https://github.com/bazo-blockchain/bazo-client/blob/56d1bcd9487b7f9a33041b28a47e1356cb226554/client/state.go#L205).
* The client still relies on a miner to create a Merkle proof: If a Bloom filter returns true, the client has to download funds transactions in order to locally create a TxBucket, derive the hash of it and further download the intermediate hashes of the miner. These are all necessary steps to create a single Merkle proof.

## Final Words

This project was submitted in fulfillment of the requirements for the degree of Master of Science in Engineering. A paper with formal definitions will be uploaded shortly and mentioned here.

Happy Holidays 🎄 
Roman
